### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "rate-limiter-flexible": "^3.0.4",
     "smile2emoji": "^3.8.5",
     "socket.io": "^4.7.2",
-    "socket.io-json-parser": "^3.0.0"
+    "socket.io-json-parser": "^3.0.0",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,13 @@
  */
 const chalk = require("chalk");
 const log = console.log;
+const RateLimit = require('express-rate-limit');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 const GameMode = {
     TIME_ATTACK: "time_attack",
     DEFENDER: "defender",
@@ -384,7 +391,7 @@ app.get("/reset", async (request, response) =>
     }
 });
 
-app.post("/reset", bodyParser.json(), async (request, response) => 
+app.post("/reset", bodyParser.json(), limiter, async (request, response) => 
 {
     log(request.body);
     var password = request.body.password;
@@ -444,7 +451,7 @@ app.get("/settings", (request, response) =>
 });
 
 //Xsolla webhooks
-app.post("/xsolla", bodyParser.json(), async (req, res) => 
+app.post("/xsolla", bodyParser.json(), limiter, async (req, res) => 
 {
     log(chalk.bgCyan("Xsolla"));
     log(req.body, req.headers.authorization);


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/5](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the route handlers that perform expensive operations, such as database access. The best way to achieve this is by using the `express-rate-limit` middleware. This middleware allows us to set a maximum number of requests that can be made to the server within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Set up a rate limiter with appropriate configuration.
3. Apply the rate limiter to the relevant route handlers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
