### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/server.js
+++ b/server.js
@@ -930,7 +930,7 @@ io.on("connection", (socket) =>
 
     socket.on("register", (_username, _password, _email, _data) =>
     {
-        log(logSocket(socket), "Wants to register:", _username, _password, _email);
+        log(logSocket(socket), "Wants to register:", _username, "[REDACTED]", _email);
         requestRegister(socket, _username, _password, _email, _data);
     });
 


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/1](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. Instead of logging the password, we can log a placeholder or simply omit it from the log message. This way, we maintain the ability to log useful information without exposing sensitive data.

The best way to fix this issue without changing existing functionality is to modify the log statement on line 933 to exclude the `_password` variable. We can replace it with a placeholder like "[REDACTED]" to indicate that a password was provided without revealing its value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
