### PR TITLE
Fix code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/server.js
+++ b/server.js
@@ -455,7 +455,7 @@ app.get("/settings", (request, response) =>
 app.post("/xsolla", bodyParser.json(), limiter, async (req, res) => 
 {
     log(chalk.bgCyan("Xsolla"));
-    log(req.body, req.headers.authorization);
+    log("Request body: %s", JSON.stringify(req.body), req.headers.authorization);
     var status = 204;
     switch (req.body.notification_type)
     {


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/3](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/3)

To fix the problem, we should ensure that the user-provided input is not directly used as a format string. Instead, we can use a `%s` specifier in the format string and pass the untrusted data as a corresponding argument. This approach ensures that the input is treated as a string and not as a format specifier.

We will modify the `console.log` statements to use `%s` for the user-provided input. Specifically, we will change the log statement on line 458 to use a format string with `%s` and pass `req.body` as an argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
