### PR TITLE
Fix code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -357,8 +357,8 @@ app.get("/reset", async (request, response) =>
             const db = client.db("arsenal");
             let collection = db.collection("accounts");   
             let query = {
-                resetToken: token
-            };	     
+                resetToken: { $eq: token }
+            };
             let res = await collection.findOne(query);
             if (res)
             {


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/6](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/6)

To fix the problem, we need to ensure that the user-provided `token` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator in the query object. This will ensure that the `token` is interpreted as a string and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
