### PR TITLE
Fix code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -405,7 +405,7 @@ app.post("/reset", bodyParser.json(), limiter, async (request, response) =>
             const db = client.db("arsenal");
             let collection = db.collection("accounts");   
             let query = {
-                resetToken: token
+                resetToken: { $eq: token }
             };	     
             var salt = bcrypt.genSaltSync(saltRounds);
             var hash = bcrypt.hashSync(password, salt);


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/7](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/7)

To fix the problem, we need to ensure that the user-provided `token` is safely embedded into the MongoDB query. We can use the `$eq` operator to ensure that the `token` is interpreted as a literal value and not as a query object. This approach will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
