### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -346,7 +346,7 @@ app.get("/", (request, response) =>
     response.send(str);
 });
 
-app.get("/reset", async (request, response) =>
+app.get("/reset", limiter, async (request, response) =>
 {
     var token = request.query.token;
     if (token)


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/4](https://github.com/WilkinGames/arsenal-online-server/security/code-scanning/4)

To fix the problem, we need to apply rate limiting to the `GET /reset` route handler to prevent potential denial-of-service attacks. This can be done by using the existing `limiter` middleware that is already defined in the code. We will add the `limiter` middleware to the `GET /reset` route handler to ensure that the number of requests to this endpoint is limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
